### PR TITLE
Reset save button to disabled after form submission

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ saveButton.addEventListener('click', function (event) {
   addToAllIdeas(idea);
   renderAllIdeas();
   form.reset();
+  saveButton.setAttribute('disabled', '');
 });
 
 for (var i = 0; i < inputs.length; i++) {


### PR DESCRIPTION
There was a bug where the save button wasn't being reset to disabled after the first time the form was submitted so the user could add an empty card. I set the disabled attribute on the save button after all of the functions have been resolved in the save button event listener.